### PR TITLE
fix(ci): fix release-mobile-app pipeline failures

### DIFF
--- a/.github/scripts/generate-whatsnew.sh
+++ b/.github/scripts/generate-whatsnew.sh
@@ -62,6 +62,6 @@ fi
 
 # Write to all locales
 for LOCALE in "${LOCALES[@]}"; do
-  echo "$NOTES" > "$WHATSNEW_DIR/whatsnew-${LOCALE}"
+  printf '%s' "$NOTES" > "$WHATSNEW_DIR/whatsnew-${LOCALE}"
   echo "Written whatsnew-${LOCALE} (${#NOTES} chars)"
 done

--- a/.github/workflows/release-mobile-app.yml
+++ b/.github/workflows/release-mobile-app.yml
@@ -281,7 +281,9 @@ jobs:
 
       - name: Select Xcode version
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+          echo "Selected Xcode version:"
+          xcodebuild -version
           echo "Available iOS SDKs:"
           xcodebuild -showsdks | grep -i ios || true
 


### PR DESCRIPTION
- Fix Android: use printf instead of echo in generate-whatsnew.sh to avoid trailing newline that pushed release notes to 501 chars (over the Play Store 500-char limit)
- Fix iOS: update Xcode from 16.2 to 16.4 (default on macos-15) since platform tools for Xcode 16.3 and older were deprecated Jan 2026

