### PR TITLE
perf: caching optimization with 24h TTLs and on-demand invalidation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -76,16 +76,6 @@ const nextConfig: NextConfig = {
           { key: "Cache-Control", value: "public, max-age=86400, stale-while-revalidate=604800" },
         ],
       },
-      // Public API v1: allow CDN caching
-      {
-        source: "/api/v1/:path*",
-        headers: [
-          {
-            key: "CDN-Cache-Control",
-            value: "public, max-age=3600, stale-while-revalidate=7200",
-          },
-        ],
-      },
       // Security headers for all routes
       {
         source: "/(.*)",

--- a/next.config.ts
+++ b/next.config.ts
@@ -63,6 +63,26 @@ const nextConfig: NextConfig = {
           { key: "Cache-Control", value: "public, max-age=3600" },
         ],
       },
+      // Static assets: immutable hashed files get long cache
+      {
+        source: "/_next/static/:path*",
+        headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
+      },
+      // Public static files (icons, manifests, images)
+      {
+        source:
+          "/:path(favicon.ico|og-image.png|manifest.json|robots.txt|sitemap.xml|llms.txt|llms-full.txt)",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=86400, stale-while-revalidate=604800" },
+        ],
+      },
+      // Public API v1: allow CDN caching
+      {
+        source: "/api/v1/:path*",
+        headers: [
+          { key: "CDN-Cache-Control", value: "public, max-age=60, stale-while-revalidate=300" },
+        ],
+      },
       // Security headers for all routes
       {
         source: "/(.*)",

--- a/next.config.ts
+++ b/next.config.ts
@@ -82,7 +82,7 @@ const nextConfig: NextConfig = {
         headers: [
           {
             key: "CDN-Cache-Control",
-            value: "public, max-age=86400, stale-while-revalidate=172800",
+            value: "public, max-age=3600, stale-while-revalidate=7200",
           },
         ],
       },

--- a/next.config.ts
+++ b/next.config.ts
@@ -80,7 +80,10 @@ const nextConfig: NextConfig = {
       {
         source: "/api/v1/:path*",
         headers: [
-          { key: "CDN-Cache-Control", value: "public, max-age=60, stale-while-revalidate=300" },
+          {
+            key: "CDN-Cache-Control",
+            value: "public, max-age=86400, stale-while-revalidate=172800",
+          },
         ],
       },
       // Security headers for all routes

--- a/prisma/migrations/20260414000000_add_city_name_index/migration.sql
+++ b/prisma/migrations/20260414000000_add_city_name_index/migration.sql
@@ -1,0 +1,5 @@
+-- Performance: index for city name lookups used by /locations, /api/v1/aeds/city, sitemap
+CREATE INDEX IF NOT EXISTS "idx_aed_locations_city_name" ON "aed_locations" ("city_name");
+
+-- Performance: index for city_code prefix queries (LEFT(city_code, 2) for province grouping)
+CREATE INDEX IF NOT EXISTS "idx_aed_locations_city_code" ON "aed_locations" ("city_code");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -362,6 +362,8 @@ model AedLocation {
   updated_at DateTime @updatedAt
 
   @@index([postal_code])
+  @@index([city_name], map: "idx_aed_locations_city_name")
+  @@index([city_code], map: "idx_aed_locations_city_code")
   @@index([city_code, district_code])
   @@index([city_code, postal_code])
   @@map("aed_locations")

--- a/src/app/api/admin/cleanup/rejected-aeds/route.ts
+++ b/src/app/api/admin/cleanup/rejected-aeds/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdmin } from "@/lib/auth";
+import { invalidateAllAedCaches } from "@/lib/cache-invalidation";
 import { prisma } from "@/lib/db";
 
 /**
@@ -117,6 +118,8 @@ export async function DELETE(request: NextRequest) {
 
       return deleted;
     });
+
+    invalidateAllAedCaches();
 
     return NextResponse.json({
       message: "DEAs eliminados exitosamente",

--- a/src/app/api/admin/deas/[id]/route.ts
+++ b/src/app/api/admin/deas/[id]/route.ts
@@ -10,6 +10,7 @@ import { prisma } from "@/lib/db";
 import { uploadToS3 } from "@/lib/s3";
 import { validateStatusTransition } from "@/lib/aed-status";
 import { recordStatusChange } from "@/lib/audit";
+import { invalidateAedCaches } from "@/lib/cache-invalidation";
 
 /**
  * GET /api/admin/deas/[id]
@@ -657,6 +658,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       return updatedAed;
     });
 
+    invalidateAedCaches({ aedId: id, cityName: result.location?.city_name ?? undefined });
+
     return NextResponse.json({
       success: true,
       data: result,
@@ -755,6 +758,8 @@ export async function DELETE(
 
       // Note: responsible_id is NOT cleaned up — it may be shared across AEDs
     });
+
+    invalidateAedCaches({ aedId: id });
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/admin/deas/[id]/route.ts
+++ b/src/app/api/admin/deas/[id]/route.ts
@@ -10,7 +10,7 @@ import { prisma } from "@/lib/db";
 import { uploadToS3 } from "@/lib/s3";
 import { validateStatusTransition } from "@/lib/aed-status";
 import { recordStatusChange } from "@/lib/audit";
-import { invalidateAedCaches } from "@/lib/cache-invalidation";
+import { invalidateAedCaches, invalidateAllAedCaches } from "@/lib/cache-invalidation";
 
 /**
  * GET /api/admin/deas/[id]
@@ -658,7 +658,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       return updatedAed;
     });
 
-    invalidateAedCaches({ aedId: id });
+    invalidateAedCaches(id);
 
     return NextResponse.json({
       success: true,
@@ -759,7 +759,7 @@ export async function DELETE(
       // Note: responsible_id is NOT cleaned up — it may be shared across AEDs
     });
 
-    invalidateAedCaches({ aedId: id });
+    invalidateAllAedCaches();
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/admin/deas/[id]/route.ts
+++ b/src/app/api/admin/deas/[id]/route.ts
@@ -658,7 +658,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       return updatedAed;
     });
 
-    invalidateAedCaches({ aedId: id, cityName: result.location?.city_name ?? undefined });
+    invalidateAedCaches({ aedId: id });
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/admin/deas/batch/route.ts
+++ b/src/app/api/admin/deas/batch/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdmin, AuthError } from "@/lib/auth";
+import { invalidateAllAedCaches } from "@/lib/cache-invalidation";
 import { prisma } from "@/lib/db";
 
 const MAX_BATCH_SIZE = 50;
@@ -111,6 +112,8 @@ export async function DELETE(request: NextRequest) {
         }
       }
     });
+
+    invalidateAllAedCaches();
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/aeds/[id]/publication/route.ts
+++ b/src/app/api/aeds/[id]/publication/route.ts
@@ -7,6 +7,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAuth } from "@/lib/auth";
+import { invalidateAedCaches } from "@/lib/cache-invalidation";
 import { prisma } from "@/lib/db";
 import type { PublicationMode } from "@/generated/client/client";
 
@@ -122,6 +123,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
       return updatedAed;
     });
+
+    invalidateAedCaches({ aedId: result.id, cityName: result.location?.city_name ?? undefined });
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/aeds/[id]/publication/route.ts
+++ b/src/app/api/aeds/[id]/publication/route.ts
@@ -124,7 +124,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       return updatedAed;
     });
 
-    invalidateAedCaches({ aedId: result.id, cityName: result.location?.city_name ?? undefined });
+    invalidateAedCaches({ aedId: result.id });
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/aeds/[id]/publication/route.ts
+++ b/src/app/api/aeds/[id]/publication/route.ts
@@ -124,7 +124,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       return updatedAed;
     });
 
-    invalidateAedCaches({ aedId: result.id });
+    invalidateAedCaches(result.id);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/aeds/[id]/route.ts
+++ b/src/app/api/aeds/[id]/route.ts
@@ -263,7 +263,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
         return updatedAed;
       });
 
-      invalidateAedCaches({ aedId: id });
+      invalidateAedCaches(id);
 
       return NextResponse.json(result);
     }
@@ -281,7 +281,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       },
     });
 
-    invalidateAedCaches({ aedId: id });
+    invalidateAedCaches(id);
 
     return NextResponse.json(updatedAed);
   } catch (error) {

--- a/src/app/api/aeds/[id]/route.ts
+++ b/src/app/api/aeds/[id]/route.ts
@@ -263,7 +263,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
         return updatedAed;
       });
 
-      invalidateAedCaches({ aedId: id, cityName: result.location?.city_name ?? undefined });
+      invalidateAedCaches({ aedId: id });
 
       return NextResponse.json(result);
     }
@@ -281,7 +281,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       },
     });
 
-    invalidateAedCaches({ aedId: id, cityName: updatedAed.location?.city_name ?? undefined });
+    invalidateAedCaches({ aedId: id });
 
     return NextResponse.json(updatedAed);
   } catch (error) {

--- a/src/app/api/aeds/[id]/route.ts
+++ b/src/app/api/aeds/[id]/route.ts
@@ -6,6 +6,7 @@ import { filterAedByPublicationMode } from "@/lib/publication-filter";
 import type { AedFullData } from "@/lib/publication-filter";
 import { validateStatusTransition } from "@/lib/aed-status";
 import { recordStatusChange } from "@/lib/audit";
+import { invalidateAedCaches } from "@/lib/cache-invalidation";
 
 interface AedImageInput {
   type: string;
@@ -262,6 +263,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
         return updatedAed;
       });
 
+      invalidateAedCaches({ aedId: id, cityName: result.location?.city_name ?? undefined });
+
       return NextResponse.json(result);
     }
 
@@ -277,6 +280,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
         responsible: true,
       },
     });
+
+    invalidateAedCaches({ aedId: id, cityName: updatedAed.location?.city_name ?? undefined });
 
     return NextResponse.json(updatedAed);
   } catch (error) {

--- a/src/app/api/aeds/bulk-publication/route.ts
+++ b/src/app/api/aeds/bulk-publication/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAuth } from "@/lib/auth";
+import { invalidateAllAedCaches } from "@/lib/cache-invalidation";
 import { prisma } from "@/lib/db";
 import type { PublicationMode } from "@/generated/client/client";
 
@@ -157,6 +158,8 @@ export async function POST(request: NextRequest) {
         history_entries_created: historyEntries.length,
       };
     });
+
+    invalidateAllAedCaches();
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/aeds/by-bounds/route.ts
+++ b/src/app/api/aeds/by-bounds/route.ts
@@ -13,7 +13,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 
-import { getCacheHeaders } from "@/lib/cache-invalidation";
+import { getInternalCacheHeaders } from "@/lib/cache-headers";
 import { getQueryStrategy, isValidBoundingBox } from "@/lib/zoom-strategy";
 import { GetAedsWithClustersUseCase } from "@/clustering/application/use-cases/GetAedsWithClustersUseCase";
 import { PostGISClusteringAdapter } from "@/clustering/infrastructure/adapters/PostGISClusteringAdapter";
@@ -90,7 +90,7 @@ export async function GET(request: NextRequest) {
     });
 
     const headers: Record<string, string> = {
-      ...getCacheHeaders(request),
+      ...getInternalCacheHeaders(request),
     };
 
     // Server-Timing header: visible in browser DevTools → Network → Timing tab

--- a/src/app/api/aeds/by-bounds/route.ts
+++ b/src/app/api/aeds/by-bounds/route.ts
@@ -89,19 +89,18 @@ export async function GET(request: NextRequest) {
       strategy,
     });
 
-    const httpResponse = NextResponse.json(response);
-    httpResponse.headers.set("Cache-Control", getCacheControl(request));
+    const headers: Record<string, string> = {
+      "Cache-Control": getCacheControl(request),
+    };
 
     // Server-Timing header: visible in browser DevTools → Network → Timing tab
     if (response.timing) {
       const { total_ms, cache_used } = response.timing;
-      httpResponse.headers.set(
-        "Server-Timing",
-        `db;dur=${total_ms};desc="DB queries", cache;desc="${cache_used ? "HIT" : "MISS"}"`
-      );
+      headers["Server-Timing"] =
+        `db;dur=${total_ms};desc="DB queries", cache;desc="${cache_used ? "HIT" : "MISS"}"`;
     }
 
-    return httpResponse;
+    return NextResponse.json(response, { headers });
   } catch (error) {
     console.error("Error fetching AEDs by bounds:", error);
     return NextResponse.json(

--- a/src/app/api/aeds/by-bounds/route.ts
+++ b/src/app/api/aeds/by-bounds/route.ts
@@ -89,11 +89,8 @@ export async function GET(request: NextRequest) {
     });
 
     const httpResponse = NextResponse.json(response);
-    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    httpResponse.headers.set(
-      "Cache-Control",
-      "public, s-maxage=86400, stale-while-revalidate=172800"
-    );
+    // Short CDN cache — internal API used by logged-in users who need to see changes quickly
+    httpResponse.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=120");
 
     // Server-Timing header: visible in browser DevTools → Network → Timing tab
     if (response.timing) {

--- a/src/app/api/aeds/by-bounds/route.ts
+++ b/src/app/api/aeds/by-bounds/route.ts
@@ -89,8 +89,9 @@ export async function GET(request: NextRequest) {
     });
 
     const httpResponse = NextResponse.json(response);
-    // Cache clustered map data for 30s, allow stale for 2min while revalidating
-    httpResponse.headers.set("Cache-Control", "public, s-maxage=30, stale-while-revalidate=120");
+    // Cache clustered map data: 5min CDN + 15min stale-while-revalidate
+    // AED data changes infrequently; cluster cache regeneration handles freshness
+    httpResponse.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
 
     // Server-Timing header: visible in browser DevTools → Network → Timing tab
     if (response.timing) {

--- a/src/app/api/aeds/by-bounds/route.ts
+++ b/src/app/api/aeds/by-bounds/route.ts
@@ -13,6 +13,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 
+import { getCacheControl } from "@/lib/cache-invalidation";
 import { getQueryStrategy, isValidBoundingBox } from "@/lib/zoom-strategy";
 import { GetAedsWithClustersUseCase } from "@/clustering/application/use-cases/GetAedsWithClustersUseCase";
 import { PostGISClusteringAdapter } from "@/clustering/infrastructure/adapters/PostGISClusteringAdapter";
@@ -89,8 +90,7 @@ export async function GET(request: NextRequest) {
     });
 
     const httpResponse = NextResponse.json(response);
-    // Short CDN cache — internal API used by logged-in users who need to see changes quickly
-    httpResponse.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=120");
+    httpResponse.headers.set("Cache-Control", getCacheControl(request));
 
     // Server-Timing header: visible in browser DevTools → Network → Timing tab
     if (response.timing) {

--- a/src/app/api/aeds/by-bounds/route.ts
+++ b/src/app/api/aeds/by-bounds/route.ts
@@ -89,9 +89,11 @@ export async function GET(request: NextRequest) {
     });
 
     const httpResponse = NextResponse.json(response);
-    // Cache clustered map data: 5min CDN + 15min stale-while-revalidate
-    // AED data changes infrequently; cluster cache regeneration handles freshness
-    httpResponse.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
+    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
+    httpResponse.headers.set(
+      "Cache-Control",
+      "public, s-maxage=86400, stale-while-revalidate=172800"
+    );
 
     // Server-Timing header: visible in browser DevTools → Network → Timing tab
     if (response.timing) {

--- a/src/app/api/aeds/by-bounds/route.ts
+++ b/src/app/api/aeds/by-bounds/route.ts
@@ -13,7 +13,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 
-import { getCacheControl } from "@/lib/cache-invalidation";
+import { getCacheHeaders } from "@/lib/cache-invalidation";
 import { getQueryStrategy, isValidBoundingBox } from "@/lib/zoom-strategy";
 import { GetAedsWithClustersUseCase } from "@/clustering/application/use-cases/GetAedsWithClustersUseCase";
 import { PostGISClusteringAdapter } from "@/clustering/infrastructure/adapters/PostGISClusteringAdapter";
@@ -90,7 +90,7 @@ export async function GET(request: NextRequest) {
     });
 
     const headers: Record<string, string> = {
-      "Cache-Control": getCacheControl(request),
+      ...getCacheHeaders(request),
     };
 
     // Server-Timing header: visible in browser DevTools → Network → Timing tab

--- a/src/app/api/aeds/nearby/route.ts
+++ b/src/app/api/aeds/nearby/route.ts
@@ -185,8 +185,8 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
+    // Short CDN cache — internal API used by logged-in users who need to see changes quickly
+    response.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=120");
 
     return response;
   } catch (error) {

--- a/src/app/api/aeds/nearby/route.ts
+++ b/src/app/api/aeds/nearby/route.ts
@@ -7,7 +7,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getCacheHeaders } from "@/lib/cache-invalidation";
+import { getInternalCacheHeaders } from "@/lib/cache-headers";
 import { prisma } from "@/lib/db";
 import { filterAedByPublicationMode } from "@/lib/publication-filter";
 import type { AedFullData } from "@/lib/publication-filter";
@@ -178,7 +178,7 @@ export async function GET(request: NextRequest) {
         query: { lat, lng, radius, limit },
         stats: { found: filteredAeds.length, searchRadius: radius },
       },
-      { headers: getCacheHeaders(request) }
+      { headers: getInternalCacheHeaders(request) }
     );
   } catch (error) {
     console.error("Error fetching nearby AEDs:", error);

--- a/src/app/api/aeds/nearby/route.ts
+++ b/src/app/api/aeds/nearby/route.ts
@@ -185,8 +185,8 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Cache nearby results for 60s, allow stale for 5min while revalidating
-    response.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=300");
+    // Cache nearby results: 5min CDN + 15min stale-while-revalidate
+    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
 
     return response;
   } catch (error) {

--- a/src/app/api/aeds/nearby/route.ts
+++ b/src/app/api/aeds/nearby/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getCacheControl } from "@/lib/cache-invalidation";
 import { prisma } from "@/lib/db";
 import { filterAedByPublicationMode } from "@/lib/publication-filter";
 import type { AedFullData } from "@/lib/publication-filter";
@@ -185,8 +186,7 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Short CDN cache — internal API used by logged-in users who need to see changes quickly
-    response.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=120");
+    response.headers.set("Cache-Control", getCacheControl(request));
 
     return response;
   } catch (error) {

--- a/src/app/api/aeds/nearby/route.ts
+++ b/src/app/api/aeds/nearby/route.ts
@@ -7,7 +7,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getCacheControl } from "@/lib/cache-invalidation";
+import { getCacheHeaders } from "@/lib/cache-invalidation";
 import { prisma } from "@/lib/db";
 import { filterAedByPublicationMode } from "@/lib/publication-filter";
 import type { AedFullData } from "@/lib/publication-filter";
@@ -178,7 +178,7 @@ export async function GET(request: NextRequest) {
         query: { lat, lng, radius, limit },
         stats: { found: filteredAeds.length, searchRadius: radius },
       },
-      { headers: { "Cache-Control": getCacheControl(request) } }
+      { headers: getCacheHeaders(request) }
     );
   } catch (error) {
     console.error("Error fetching nearby AEDs:", error);

--- a/src/app/api/aeds/nearby/route.ts
+++ b/src/app/api/aeds/nearby/route.ts
@@ -171,24 +171,15 @@ export async function GET(request: NextRequest) {
         distance: aed.id ? (distanceMap.get(aed.id) ?? 0) : 0,
       }));
 
-    const response = NextResponse.json({
-      success: true,
-      data: filteredAeds,
-      query: {
-        lat,
-        lng,
-        radius,
-        limit,
+    return NextResponse.json(
+      {
+        success: true,
+        data: filteredAeds,
+        query: { lat, lng, radius, limit },
+        stats: { found: filteredAeds.length, searchRadius: radius },
       },
-      stats: {
-        found: filteredAeds.length,
-        searchRadius: radius,
-      },
-    });
-
-    response.headers.set("Cache-Control", getCacheControl(request));
-
-    return response;
+      { headers: { "Cache-Control": getCacheControl(request) } }
+    );
   } catch (error) {
     console.error("Error fetching nearby AEDs:", error);
     return NextResponse.json(

--- a/src/app/api/aeds/nearby/route.ts
+++ b/src/app/api/aeds/nearby/route.ts
@@ -185,8 +185,8 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Cache nearby results: 5min CDN + 15min stale-while-revalidate
-    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
+    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
+    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
 
     return response;
   } catch (error) {

--- a/src/app/api/aeds/route.ts
+++ b/src/app/api/aeds/route.ts
@@ -205,20 +205,19 @@ export async function GET(request: NextRequest) {
       .map((aed) => filterAedByPublicationMode(aed as AedFullData))
       .filter((aed): aed is NonNullable<typeof aed> => aed !== null);
 
-    const response = NextResponse.json({
-      success: true,
-      data: filteredAeds,
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit),
+    return NextResponse.json(
+      {
+        success: true,
+        data: filteredAeds,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+        },
       },
-    });
-
-    response.headers.set("Cache-Control", getCacheControl(request));
-
-    return response;
+      { headers: { "Cache-Control": getCacheControl(request) } }
+    );
   } catch (error) {
     console.error("Error fetching AEDs:", error);
     return NextResponse.json(

--- a/src/app/api/aeds/route.ts
+++ b/src/app/api/aeds/route.ts
@@ -215,8 +215,8 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Cache public AED list for 60s, allow stale for 5min while revalidating
-    response.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=300");
+    // Cache public AED list: 5min CDN + 15min stale-while-revalidate
+    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
 
     return response;
   } catch (error) {

--- a/src/app/api/aeds/route.ts
+++ b/src/app/api/aeds/route.ts
@@ -11,7 +11,7 @@ import { getUserFromRequest } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { recordStatusChange } from "@/lib/audit";
-import { invalidateAedCaches } from "@/lib/cache-invalidation";
+import { invalidateAedCaches, getCacheControl } from "@/lib/cache-invalidation";
 import { filterAedByPublicationMode } from "@/lib/publication-filter";
 import type { AedFullData } from "@/lib/publication-filter";
 import { getDuplicateDetector } from "@/duplicate-detection/infrastructure/factory";
@@ -216,8 +216,7 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Short CDN cache — internal API used by logged-in users who need to see changes quickly
-    response.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=120");
+    response.headers.set("Cache-Control", getCacheControl(request));
 
     return response;
   } catch (error) {

--- a/src/app/api/aeds/route.ts
+++ b/src/app/api/aeds/route.ts
@@ -11,6 +11,7 @@ import { getUserFromRequest } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { recordStatusChange } from "@/lib/audit";
+import { invalidateAedCaches } from "@/lib/cache-invalidation";
 import { filterAedByPublicationMode } from "@/lib/publication-filter";
 import type { AedFullData } from "@/lib/publication-filter";
 import { getDuplicateDetector } from "@/duplicate-detection/infrastructure/factory";
@@ -215,8 +216,8 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Cache public AED list: 5min CDN + 15min stale-while-revalidate
-    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
+    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
+    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
 
     return response;
   } catch (error) {
@@ -557,6 +558,8 @@ export async function POST(request: NextRequest) {
 
       return newAed;
     });
+
+    invalidateAedCaches({ aedId: aed.id, cityName: aed.location?.city_name ?? undefined });
 
     return NextResponse.json(
       {

--- a/src/app/api/aeds/route.ts
+++ b/src/app/api/aeds/route.ts
@@ -11,7 +11,8 @@ import { getUserFromRequest } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { recordStatusChange } from "@/lib/audit";
-import { invalidateAedCaches, getCacheHeaders } from "@/lib/cache-invalidation";
+import { getInternalCacheHeaders } from "@/lib/cache-headers";
+import { invalidateAedCaches } from "@/lib/cache-invalidation";
 import { filterAedByPublicationMode } from "@/lib/publication-filter";
 import type { AedFullData } from "@/lib/publication-filter";
 import { getDuplicateDetector } from "@/duplicate-detection/infrastructure/factory";
@@ -216,7 +217,7 @@ export async function GET(request: NextRequest) {
           totalPages: Math.ceil(total / limit),
         },
       },
-      { headers: getCacheHeaders(request) }
+      { headers: getInternalCacheHeaders(request) }
     );
   } catch (error) {
     console.error("Error fetching AEDs:", error);
@@ -557,7 +558,7 @@ export async function POST(request: NextRequest) {
       return newAed;
     });
 
-    invalidateAedCaches({ aedId: aed.id });
+    invalidateAedCaches(aed.id);
 
     return NextResponse.json(
       {

--- a/src/app/api/aeds/route.ts
+++ b/src/app/api/aeds/route.ts
@@ -558,7 +558,7 @@ export async function POST(request: NextRequest) {
       return newAed;
     });
 
-    invalidateAedCaches({ aedId: aed.id, cityName: aed.location?.city_name ?? undefined });
+    invalidateAedCaches({ aedId: aed.id });
 
     return NextResponse.json(
       {

--- a/src/app/api/aeds/route.ts
+++ b/src/app/api/aeds/route.ts
@@ -216,8 +216,8 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
+    // Short CDN cache — internal API used by logged-in users who need to see changes quickly
+    response.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=120");
 
     return response;
   } catch (error) {

--- a/src/app/api/aeds/route.ts
+++ b/src/app/api/aeds/route.ts
@@ -11,7 +11,7 @@ import { getUserFromRequest } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { recordStatusChange } from "@/lib/audit";
-import { invalidateAedCaches, getCacheControl } from "@/lib/cache-invalidation";
+import { invalidateAedCaches, getCacheHeaders } from "@/lib/cache-invalidation";
 import { filterAedByPublicationMode } from "@/lib/publication-filter";
 import type { AedFullData } from "@/lib/publication-filter";
 import { getDuplicateDetector } from "@/duplicate-detection/infrastructure/factory";
@@ -216,7 +216,7 @@ export async function GET(request: NextRequest) {
           totalPages: Math.ceil(total / limit),
         },
       },
-      { headers: { "Cache-Control": getCacheControl(request) } }
+      { headers: getCacheHeaders(request) }
     );
   } catch (error) {
     console.error("Error fetching AEDs:", error);

--- a/src/app/api/v1/aeds/[id]/route.ts
+++ b/src/app/api/v1/aeds/[id]/route.ts
@@ -126,7 +126,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       meta: { api_version: "v1" },
     });
 
-    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
+    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
+    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/[id]/route.ts
+++ b/src/app/api/v1/aeds/[id]/route.ts
@@ -121,16 +121,16 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       web_url: `https://deamap.es/dea/${filtered.id}`,
     };
 
-    const response = NextResponse.json({
-      data,
-      meta: { api_version: "v1" },
-    });
-
-    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    response.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=7200");
-    response.headers.set("Access-Control-Allow-Origin", "*");
-
-    return response;
+    return NextResponse.json(
+      { data, meta: { api_version: "v1" } },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+          "CDN-Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
   } catch (error) {
     console.error("[Public API v1] Error fetching AED:", error);
     return NextResponse.json(

--- a/src/app/api/v1/aeds/[id]/route.ts
+++ b/src/app/api/v1/aeds/[id]/route.ts
@@ -126,7 +126,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       meta: { api_version: "v1" },
     });
 
-    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=600");
+    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/[id]/route.ts
+++ b/src/app/api/v1/aeds/[id]/route.ts
@@ -127,7 +127,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     });
 
     // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
+    response.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=7200");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/[id]/route.ts
+++ b/src/app/api/v1/aeds/[id]/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 
+import { V1_PUBLIC_HEADERS } from "@/lib/cache-headers";
 import { prisma } from "@/lib/db";
 import { filterAedByPublicationMode } from "@/lib/publication-filter";
 import type { AedFullData } from "@/lib/publication-filter";
@@ -121,16 +122,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       web_url: `https://deamap.es/dea/${filtered.id}`,
     };
 
-    return NextResponse.json(
-      { data, meta: { api_version: "v1" } },
-      {
-        headers: {
-          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
-          "CDN-Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
-          "Access-Control-Allow-Origin": "*",
-        },
-      }
-    );
+    return NextResponse.json({ data, meta: { api_version: "v1" } }, { headers: V1_PUBLIC_HEADERS });
   } catch (error) {
     console.error("[Public API v1] Error fetching AED:", error);
     return NextResponse.json(

--- a/src/app/api/v1/aeds/city/[city]/route.ts
+++ b/src/app/api/v1/aeds/city/[city]/route.ts
@@ -138,7 +138,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       },
     });
 
-    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
+    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
+    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/city/[city]/route.ts
+++ b/src/app/api/v1/aeds/city/[city]/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { PUBLISHED_AED_WHERE } from "@/lib/aed-status";
+import { V1_PUBLIC_HEADERS } from "@/lib/cache-headers";
 import { prisma } from "@/lib/db";
 import { publicApiRateLimiter } from "@/lib/rate-limit-public-api";
 
@@ -138,13 +139,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
           api_version: "v1",
         },
       },
-      {
-        headers: {
-          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
-          "CDN-Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
-          "Access-Control-Allow-Origin": "*",
-        },
-      }
+      { headers: V1_PUBLIC_HEADERS }
     );
   } catch (error) {
     console.error("[Public API v1] Error fetching city AEDs:", error);

--- a/src/app/api/v1/aeds/city/[city]/route.ts
+++ b/src/app/api/v1/aeds/city/[city]/route.ts
@@ -138,7 +138,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       },
     });
 
-    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=600");
+    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/city/[city]/route.ts
+++ b/src/app/api/v1/aeds/city/[city]/route.ts
@@ -126,23 +126,26 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       web_url: `https://deamap.es/dea/${aed.id}`,
     }));
 
-    const response = NextResponse.json({
-      data,
-      meta: {
-        city: actualCityName,
-        total,
-        limit,
-        offset,
-        has_more: offset + limit < total,
-        api_version: "v1",
+    return NextResponse.json(
+      {
+        data,
+        meta: {
+          city: actualCityName,
+          total,
+          limit,
+          offset,
+          has_more: offset + limit < total,
+          api_version: "v1",
+        },
       },
-    });
-
-    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    response.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=7200");
-    response.headers.set("Access-Control-Allow-Origin", "*");
-
-    return response;
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+          "CDN-Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
   } catch (error) {
     console.error("[Public API v1] Error fetching city AEDs:", error);
     return NextResponse.json(

--- a/src/app/api/v1/aeds/city/[city]/route.ts
+++ b/src/app/api/v1/aeds/city/[city]/route.ts
@@ -139,7 +139,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     });
 
     // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
+    response.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=7200");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/nearby/route.ts
+++ b/src/app/api/v1/aeds/nearby/route.ts
@@ -174,7 +174,7 @@ export async function GET(request: NextRequest) {
     });
 
     // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
+    response.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=7200");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/nearby/route.ts
+++ b/src/app/api/v1/aeds/nearby/route.ts
@@ -13,6 +13,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 
+import { V1_PUBLIC_HEADERS } from "@/lib/cache-headers";
 import { prisma } from "@/lib/db";
 import { filterAedByPublicationMode } from "@/lib/publication-filter";
 import type { AedFullData } from "@/lib/publication-filter";
@@ -173,13 +174,7 @@ export async function GET(request: NextRequest) {
           api_version: "v1",
         },
       },
-      {
-        headers: {
-          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
-          "CDN-Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
-          "Access-Control-Allow-Origin": "*",
-        },
-      }
+      { headers: V1_PUBLIC_HEADERS }
     );
   } catch (error) {
     console.error("[Public API v1] Error fetching nearby AEDs:", error);

--- a/src/app/api/v1/aeds/nearby/route.ts
+++ b/src/app/api/v1/aeds/nearby/route.ts
@@ -173,7 +173,8 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
+    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
+    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/nearby/route.ts
+++ b/src/app/api/v1/aeds/nearby/route.ts
@@ -164,20 +164,23 @@ export async function GET(request: NextRequest) {
         web_url: `https://deamap.es/dea/${aed.id}`,
       }));
 
-    const response = NextResponse.json({
-      data,
-      meta: {
-        total: data.length,
-        query: { lat, lng, radius_km: radius, limit },
-        api_version: "v1",
+    return NextResponse.json(
+      {
+        data,
+        meta: {
+          total: data.length,
+          query: { lat, lng, radius_km: radius, limit },
+          api_version: "v1",
+        },
       },
-    });
-
-    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    response.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=7200");
-    response.headers.set("Access-Control-Allow-Origin", "*");
-
-    return response;
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+          "CDN-Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
   } catch (error) {
     console.error("[Public API v1] Error fetching nearby AEDs:", error);
     return NextResponse.json(

--- a/src/app/api/v1/aeds/nearby/route.ts
+++ b/src/app/api/v1/aeds/nearby/route.ts
@@ -173,7 +173,7 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    response.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=300");
+    response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=900");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/stats/route.ts
+++ b/src/app/api/v1/aeds/stats/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { PUBLISHED_AED_WHERE } from "@/lib/aed-status";
+import { V1_PUBLIC_HEADERS } from "@/lib/cache-headers";
 import { prisma } from "@/lib/db";
 import { publicApiRateLimiter } from "@/lib/rate-limit-public-api";
 
@@ -60,13 +61,7 @@ export async function GET(request: NextRequest) {
         },
         meta: { api_version: "v1" },
       },
-      {
-        headers: {
-          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
-          "CDN-Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
-          "Access-Control-Allow-Origin": "*",
-        },
-      }
+      { headers: V1_PUBLIC_HEADERS }
     );
   } catch (error) {
     console.error("[Public API v1] Error fetching stats:", error);

--- a/src/app/api/v1/aeds/stats/route.ts
+++ b/src/app/api/v1/aeds/stats/route.ts
@@ -60,7 +60,8 @@ export async function GET(request: NextRequest) {
       meta: { api_version: "v1" },
     });
 
-    response.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=7200");
+    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
+    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/stats/route.ts
+++ b/src/app/api/v1/aeds/stats/route.ts
@@ -61,7 +61,7 @@ export async function GET(request: NextRequest) {
     });
 
     // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    response.headers.set("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=172800");
+    response.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=7200");
     response.headers.set("Access-Control-Allow-Origin", "*");
 
     return response;

--- a/src/app/api/v1/aeds/stats/route.ts
+++ b/src/app/api/v1/aeds/stats/route.ts
@@ -48,23 +48,26 @@ export async function GET(request: NextRequest) {
       `,
     ]);
 
-    const response = NextResponse.json({
-      data: {
-        total_aeds: totalAeds,
-        total_cities: totalCitiesResult[0]?.count ?? 0,
-        top_cities: topCities.map((c) => ({
-          name: c.city_name,
-          count: c.count,
-        })),
+    return NextResponse.json(
+      {
+        data: {
+          total_aeds: totalAeds,
+          total_cities: totalCitiesResult[0]?.count ?? 0,
+          top_cities: topCities.map((c) => ({
+            name: c.city_name,
+            count: c.count,
+          })),
+        },
+        meta: { api_version: "v1" },
       },
-      meta: { api_version: "v1" },
-    });
-
-    // Cache 24h + 48h SWR — invalidated on-demand when AEDs change
-    response.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=7200");
-    response.headers.set("Access-Control-Allow-Origin", "*");
-
-    return response;
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+          "CDN-Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
   } catch (error) {
     console.error("[Public API v1] Error fetching stats:", error);
     return NextResponse.json(

--- a/src/app/api/v1/openapi.json/route.ts
+++ b/src/app/api/v1/openapi.json/route.ts
@@ -6,6 +6,8 @@
 
 import { NextResponse } from "next/server";
 
+import { V1_OPENAPI_HEADERS } from "@/lib/cache-headers";
+
 const spec = {
   openapi: "3.1.0",
   info: {
@@ -348,11 +350,5 @@ const spec = {
 };
 
 export async function GET() {
-  return NextResponse.json(spec, {
-    headers: {
-      "Cache-Control": "public, s-maxage=86400",
-      "CDN-Cache-Control": "public, s-maxage=86400",
-      "Access-Control-Allow-Origin": "*",
-    },
-  });
+  return NextResponse.json(spec, { headers: V1_OPENAPI_HEADERS });
 }

--- a/src/app/api/v1/openapi.json/route.ts
+++ b/src/app/api/v1/openapi.json/route.ts
@@ -348,8 +348,11 @@ const spec = {
 };
 
 export async function GET() {
-  const response = NextResponse.json(spec);
-  response.headers.set("Cache-Control", "public, s-maxage=86400");
-  response.headers.set("Access-Control-Allow-Origin", "*");
-  return response;
+  return NextResponse.json(spec, {
+    headers: {
+      "Cache-Control": "public, s-maxage=86400",
+      "CDN-Cache-Control": "public, s-maxage=86400",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
 }

--- a/src/app/api/verify/[id]/complete/route.ts
+++ b/src/app/api/verify/[id]/complete/route.ts
@@ -261,7 +261,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       console.log("🎉 Verificación completada exitosamente");
     }
 
-    invalidateAedCaches({ aedId: id });
+    invalidateAedCaches(id);
 
     return NextResponse.json({
       ...updatedValidation,

--- a/src/app/api/verify/[id]/complete/route.ts
+++ b/src/app/api/verify/[id]/complete/route.ts
@@ -6,6 +6,7 @@ import { uploadToS3 } from "@/lib/s3";
 import { buildImageKey, extractExtension } from "@/lib/s3-utils";
 import { processVerificationImages, type ImageToProcess } from "@/lib/imageProcessing";
 import { recordStatusChange } from "@/lib/audit";
+import { invalidateAedCaches } from "@/lib/cache-invalidation";
 import type { ProcessedImageData } from "@/types/verification";
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -259,6 +260,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     } else {
       console.log("🎉 Verificación completada exitosamente");
     }
+
+    invalidateAedCaches({ aedId: id });
 
     return NextResponse.json({
       ...updatedValidation,

--- a/src/app/locations/[country]/[region]/[city]/page.tsx
+++ b/src/app/locations/[country]/[region]/[city]/page.tsx
@@ -19,7 +19,7 @@ import { safeJsonLd } from "@/lib/json-ld";
 const ITEMS_PER_PAGE = 50;
 
 export const dynamicParams = true;
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 interface Props {
   params: Promise<{ country: string; region: string; city: string }>;

--- a/src/app/locations/[country]/[region]/page.tsx
+++ b/src/app/locations/[country]/[region]/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/lib/geography";
 import { safeJsonLd } from "@/lib/json-ld";
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 export const dynamicParams = true;
 
 interface Props {

--- a/src/app/locations/[country]/page.tsx
+++ b/src/app/locations/[country]/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/lib/geography";
 import { safeJsonLd } from "@/lib/json-ld";
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 export const dynamicParams = true;
 
 interface Props {

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -6,7 +6,7 @@ import { prisma } from "@/lib/db";
 import { COUNTRIES, countryPath } from "@/lib/geography";
 import { safeJsonLd } from "@/lib/json-ld";
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export const metadata: Metadata = {
   title: "Desfibriladores en el mundo - Directorio por país",

--- a/src/batch/application/processors/AedCsvImportProcessor.ts
+++ b/src/batch/application/processors/AedCsvImportProcessor.ts
@@ -23,6 +23,7 @@ import { randomUUID } from "crypto";
 import { DownloadAndUploadImageUseCase } from "@/storage/application/use-cases/DownloadAndUploadImageUseCase";
 import * as os from "os";
 import * as path from "path";
+import { invalidateAllAedCaches } from "@/lib/cache-invalidation";
 
 interface CsvRecord {
   [key: string]: string;
@@ -897,6 +898,7 @@ export class AedCsvImportProcessor extends BaseBatchJobProcessor<AedCsvImportCon
   }
 
   async finalize(job: BatchJob): Promise<JobResult> {
+    invalidateAllAedCaches();
     return JobResult.fromProgress(job.progress).complete();
   }
 

--- a/src/hooks/useAedsByBounds.ts
+++ b/src/hooks/useAedsByBounds.ts
@@ -64,7 +64,6 @@ export function useAedsByBounds(
   });
   const [strategy, setStrategy] = useState<string>("full");
 
-  // eslint-disable-next-line no-undef
   const abortControllerRef = useRef<AbortController | null>(null);
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastFetchedBoundsRef = useRef<BoundingBox | null>(null);
@@ -89,17 +88,18 @@ export function useAedsByBounds(
         abortControllerRef.current.abort();
       }
 
-      // eslint-disable-next-line no-undef
       abortControllerRef.current = new AbortController();
 
       setLoading(true);
       setError(null);
 
+      // Round coordinates to reduce unique URLs and improve browser HTTP cache hits
+      const precision = zoomLevel >= 14 ? 4 : zoomLevel >= 10 ? 3 : 2;
       const params = new URLSearchParams({
-        minLat: boundingBox.minLat.toFixed(6),
-        maxLat: boundingBox.maxLat.toFixed(6),
-        minLng: boundingBox.minLng.toFixed(6),
-        maxLng: boundingBox.maxLng.toFixed(6),
+        minLat: boundingBox.minLat.toFixed(precision),
+        maxLat: boundingBox.maxLat.toFixed(precision),
+        minLng: boundingBox.minLng.toFixed(precision),
+        maxLng: boundingBox.maxLng.toFixed(precision),
         zoom: zoomLevel.toString(),
       });
 

--- a/src/import/application/services/ExternalSyncService.ts
+++ b/src/import/application/services/ExternalSyncService.ts
@@ -43,6 +43,7 @@ import {
   DEFAULT_CHUNK_MAX_RECORDS,
 } from "@/import/constants";
 import { appendInternalNote, recordStatusChange } from "@/lib/audit";
+import { invalidateAllAedCaches } from "@/lib/cache-invalidation";
 import { SYSTEM_USER_UUID } from "@/constants/system";
 
 // ============================================================
@@ -571,7 +572,10 @@ export class ExternalSyncService {
       console.error(`[Sync] Failed to finalize data source ${dataSourceId}:`, error);
     }
 
-    // 2. Disappearance detection — skip for dry runs or if no syncStartTime
+    // 2. Invalidate all caches after bulk sync
+    invalidateAllAedCaches();
+
+    // 3. Disappearance detection — skip for dry runs or if no syncStartTime
     if (dryRun || !syncStartTime) return;
 
     await this.detectDisappearedIdentifiers(dataSourceId, syncStartTime);

--- a/src/lib/cache-headers.ts
+++ b/src/lib/cache-headers.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared HTTP cache headers for API responses.
+ *
+ * | Route              | Audience           | TTL                        |
+ * |--------------------|--------------------|----------------------------|
+ * | /api/aeds/*        | App (map, list)    | 5 min (anon), none (auth)  |
+ * | /api/v1/*          | External consumers | 1h                         |
+ * | /api/v1/openapi    | Developers         | 24h                        |
+ * | /locations/* (ISR) | SEO / crawlers     | 24h (managed by Next.js)   |
+ *
+ * Both Cache-Control and CDN-Cache-Control are set because Next.js 15
+ * may override Cache-Control on route handlers. CDN-Cache-Control is
+ * always respected by Vercel Edge.
+ */
+
+import type { NextRequest } from "next/server";
+
+/** Headers for public API v1 data endpoints (1h TTL). */
+export const V1_PUBLIC_HEADERS = {
+  "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+  "CDN-Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+  "Access-Control-Allow-Origin": "*",
+} as const;
+
+/** Headers for the OpenAPI spec endpoint (24h TTL, rarely changes). */
+export const V1_OPENAPI_HEADERS = {
+  "Cache-Control": "public, s-maxage=86400",
+  "CDN-Cache-Control": "public, s-maxage=86400",
+  "Access-Control-Allow-Origin": "*",
+} as const;
+
+/**
+ * Dynamic cache headers for internal API routes (/api/aeds/*).
+ * - Authenticated → private, no-store (always fresh)
+ * - Anonymous → 5 min CDN cache
+ */
+export function getInternalCacheHeaders(request: NextRequest): Record<string, string> {
+  const hasAuth =
+    request.cookies.has("auth-token") ||
+    request.headers.get("authorization")?.startsWith("Bearer ");
+
+  if (hasAuth) {
+    return {
+      "Cache-Control": "private, no-store",
+      "CDN-Cache-Control": "private, no-store",
+    };
+  }
+  return {
+    "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+    "CDN-Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+  };
+}

--- a/src/lib/cache-invalidation.ts
+++ b/src/lib/cache-invalidation.ts
@@ -1,0 +1,54 @@
+/**
+ * On-demand cache invalidation for AED data.
+ *
+ * Strategy: all public endpoints use long TTLs (24h) with stale-while-revalidate.
+ * When AED data changes, we invalidate specific paths so Vercel purges the CDN
+ * cache and the next request gets fresh data.
+ *
+ * Uses Next.js `revalidatePath()` which works both for ISR pages and API routes
+ * cached at the CDN level on Vercel.
+ */
+
+import { revalidatePath } from "next/cache";
+
+/**
+ * Invalidate caches after a single AED is created, updated, or deleted.
+ * Call this AFTER the database transaction commits successfully.
+ */
+export function invalidateAedCaches(options?: {
+  aedId?: string;
+  cityName?: string;
+  communitySlug?: string;
+}): void {
+  // Map/list endpoints — always invalidate on any AED change
+  revalidatePath("/api/aeds", "page");
+  revalidatePath("/api/aeds/by-bounds", "page");
+  revalidatePath("/api/aeds/nearby", "page");
+  revalidatePath("/api/v1/aeds/stats", "page");
+  revalidatePath("/api/v1/aeds/nearby", "page");
+
+  // ISR location pages
+  revalidatePath("/locations", "page");
+  revalidatePath("/locations/spain", "page");
+
+  // Specific AED detail
+  if (options?.aedId) {
+    revalidatePath(`/api/v1/aeds/${options.aedId}`, "page");
+  }
+
+  // Community page
+  if (options?.communitySlug) {
+    revalidatePath(`/locations/spain/${options.communitySlug}`, "page");
+  }
+}
+
+/**
+ * Invalidate ALL AED caches. Use for bulk operations (imports, batch deletes).
+ */
+export function invalidateAllAedCaches(): void {
+  invalidateAedCaches();
+
+  // Also invalidate sitemap and all location sub-pages
+  revalidatePath("/sitemap.xml", "page");
+  revalidatePath("/locations/spain", "layout");
+}

--- a/src/lib/cache-invalidation.ts
+++ b/src/lib/cache-invalidation.ts
@@ -1,12 +1,13 @@
 /**
  * On-demand cache invalidation for AED data.
  *
- * Strategy: all public endpoints use long TTLs (24h) with stale-while-revalidate.
- * When AED data changes, we invalidate specific paths so Vercel purges the CDN
- * cache and the next request gets fresh data.
+ * Cache strategy:
+ * - Internal APIs (/api/aeds/*): 60s TTL — users see changes within ~1 min
+ * - Public APIs (/api/v1/*): 24h TTL — invalidated on-demand when AEDs change
+ * - ISR pages (/locations/*): 24h revalidate — invalidated on-demand
  *
- * Uses Next.js `revalidatePath()` which works both for ISR pages and API routes
- * cached at the CDN level on Vercel.
+ * Uses Next.js `revalidatePath()` to purge Vercel CDN cache for long-TTL routes.
+ * Internal APIs don't need invalidation — their short TTL handles freshness.
  */
 
 import { revalidatePath } from "next/cache";
@@ -20,18 +21,15 @@ export function invalidateAedCaches(options?: {
   cityName?: string;
   communitySlug?: string;
 }): void {
-  // Map/list endpoints — always invalidate on any AED change
-  revalidatePath("/api/aeds", "page");
-  revalidatePath("/api/aeds/by-bounds", "page");
-  revalidatePath("/api/aeds/nearby", "page");
+  // Public API v1 endpoints (24h TTL — need explicit invalidation)
   revalidatePath("/api/v1/aeds/stats", "page");
   revalidatePath("/api/v1/aeds/nearby", "page");
 
-  // ISR location pages
+  // ISR location pages (24h revalidate)
   revalidatePath("/locations", "page");
   revalidatePath("/locations/spain", "page");
 
-  // Specific AED detail
+  // Specific AED detail (public API)
   if (options?.aedId) {
     revalidatePath(`/api/v1/aeds/${options.aedId}`, "page");
   }

--- a/src/lib/cache-invalidation.ts
+++ b/src/lib/cache-invalidation.ts
@@ -20,18 +20,28 @@ import { revalidatePath } from "next/cache";
 // ── Cache-Control helpers ───────────────────────────────────────────
 
 /**
- * Cache-Control for internal API routes (/api/aeds/*).
+ * Cache headers for internal API routes (/api/aeds/*).
  * Authenticated users always get fresh data; anonymous users get 5 min CDN cache.
+ *
+ * Returns both Cache-Control and CDN-Cache-Control because Next.js 15 on Vercel
+ * may override Cache-Control on route handlers. CDN-Cache-Control is respected
+ * by Vercel Edge regardless.
  */
-export function getCacheControl(request: NextRequest): string {
+export function getCacheHeaders(request: NextRequest): Record<string, string> {
   const hasAuth =
     request.cookies.has("auth-token") ||
     request.headers.get("authorization")?.startsWith("Bearer ");
 
   if (hasAuth) {
-    return "private, no-store";
+    return {
+      "Cache-Control": "private, no-store",
+      "CDN-Cache-Control": "private, no-store",
+    };
   }
-  return "public, s-maxage=300, stale-while-revalidate=60";
+  return {
+    "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+    "CDN-Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+  };
 }
 
 // ── On-demand invalidation ──────────────────────────────────────────

--- a/src/lib/cache-invalidation.ts
+++ b/src/lib/cache-invalidation.ts
@@ -3,11 +3,14 @@
  *
  * Cache strategy:
  * - Authenticated requests: no CDN cache (private, no-store) — always fresh
- * - Anonymous requests: 24h CDN cache — invalidated on-demand when AEDs change
+ * - Anonymous requests: 24h CDN cache — invalidated surgically when AEDs change
  * - Public API v1: 24h CDN cache — invalidated on-demand
  * - ISR pages (/locations/*): 24h revalidate — invalidated on-demand
  *
- * Uses Next.js `revalidatePath()` to purge Vercel CDN cache for long-TTL routes.
+ * IMPORTANT: single-AED mutations only invalidate targeted paths (detail, stats,
+ * city page). Map/list endpoints (by-bounds, nearby, /api/aeds) are NOT purged
+ * on every change — their SWR policy handles gradual freshness. Only bulk
+ * operations (imports, batch deletes) purge everything.
  */
 
 import type { NextRequest } from "next/server";
@@ -31,44 +34,39 @@ export function getCacheControl(request: NextRequest): string {
 
 /**
  * Invalidate caches after a single AED is created, updated, or deleted.
+ * Only targets specific paths — does NOT purge map/list endpoints.
+ *
  * Call this AFTER the database transaction commits successfully.
  */
-export function invalidateAedCaches(options?: {
-  aedId?: string;
-  cityName?: string;
-  communitySlug?: string;
-}): void {
-  // Internal API endpoints (cached for anonymous users)
-  revalidatePath("/api/aeds", "page");
-  revalidatePath("/api/aeds/by-bounds", "page");
-  revalidatePath("/api/aeds/nearby", "page");
-
-  // Public API v1 endpoints (24h TTL)
+export function invalidateAedCaches(options?: { aedId?: string; communitySlug?: string }): void {
+  // Stats may change (total count, city counts)
   revalidatePath("/api/v1/aeds/stats", "page");
-  revalidatePath("/api/v1/aeds/nearby", "page");
-
-  // ISR location pages (24h revalidate)
-  revalidatePath("/locations", "page");
-  revalidatePath("/locations/spain", "page");
 
   // Specific AED detail (public API)
   if (options?.aedId) {
     revalidatePath(`/api/v1/aeds/${options.aedId}`, "page");
   }
 
-  // Community page
+  // Community location page (AED count per community)
   if (options?.communitySlug) {
     revalidatePath(`/locations/spain/${options.communitySlug}`, "page");
   }
 }
 
 /**
- * Invalidate ALL AED caches. Use for bulk operations (imports, batch deletes).
+ * Invalidate ALL AED caches. Use ONLY for bulk operations
+ * (imports, batch deletes, bulk publication changes).
  */
 export function invalidateAllAedCaches(): void {
-  invalidateAedCaches();
+  // Map/list endpoints — only purged on bulk changes
+  revalidatePath("/api/aeds", "page");
+  revalidatePath("/api/aeds/by-bounds", "page");
+  revalidatePath("/api/aeds/nearby", "page");
+  revalidatePath("/api/v1/aeds/nearby", "page");
+  revalidatePath("/api/v1/aeds/stats", "page");
 
-  // Also invalidate sitemap and all location sub-pages
-  revalidatePath("/sitemap.xml", "page");
+  // All ISR location pages
+  revalidatePath("/locations", "page");
   revalidatePath("/locations/spain", "layout");
+  revalidatePath("/sitemap.xml", "page");
 }

--- a/src/lib/cache-invalidation.ts
+++ b/src/lib/cache-invalidation.ts
@@ -2,15 +2,32 @@
  * On-demand cache invalidation for AED data.
  *
  * Cache strategy:
- * - Internal APIs (/api/aeds/*): 60s TTL — users see changes within ~1 min
- * - Public APIs (/api/v1/*): 24h TTL — invalidated on-demand when AEDs change
+ * - Authenticated requests: no CDN cache (private, no-store) — always fresh
+ * - Anonymous requests: 24h CDN cache — invalidated on-demand when AEDs change
+ * - Public API v1: 24h CDN cache — invalidated on-demand
  * - ISR pages (/locations/*): 24h revalidate — invalidated on-demand
  *
  * Uses Next.js `revalidatePath()` to purge Vercel CDN cache for long-TTL routes.
- * Internal APIs don't need invalidation — their short TTL handles freshness.
  */
 
+import type { NextRequest } from "next/server";
 import { revalidatePath } from "next/cache";
+
+/**
+ * Returns the appropriate Cache-Control header based on authentication.
+ * Authenticated users get no cache (instant freshness after mutations).
+ * Anonymous users get long CDN cache (purged on-demand via invalidation).
+ */
+export function getCacheControl(request: NextRequest): string {
+  const hasAuth =
+    request.cookies.has("auth-token") ||
+    request.headers.get("authorization")?.startsWith("Bearer ");
+
+  if (hasAuth) {
+    return "private, no-store";
+  }
+  return "public, s-maxage=86400, stale-while-revalidate=172800";
+}
 
 /**
  * Invalidate caches after a single AED is created, updated, or deleted.
@@ -21,7 +38,12 @@ export function invalidateAedCaches(options?: {
   cityName?: string;
   communitySlug?: string;
 }): void {
-  // Public API v1 endpoints (24h TTL — need explicit invalidation)
+  // Internal API endpoints (cached for anonymous users)
+  revalidatePath("/api/aeds", "page");
+  revalidatePath("/api/aeds/by-bounds", "page");
+  revalidatePath("/api/aeds/nearby", "page");
+
+  // Public API v1 endpoints (24h TTL)
   revalidatePath("/api/v1/aeds/stats", "page");
   revalidatePath("/api/v1/aeds/nearby", "page");
 

--- a/src/lib/cache-invalidation.ts
+++ b/src/lib/cache-invalidation.ts
@@ -1,89 +1,36 @@
 /**
- * Cache and on-demand invalidation for AED data.
+ * On-demand cache invalidation for AED data.
  *
- * Cache strategy by audience:
+ * revalidatePath only works on ISR pages and fetch-cached data — NOT on
+ * API route handlers that set their own Cache-Control headers. Route
+ * handler freshness is managed by TTLs in cache-headers.ts.
  *
- * | Route                  | Audience            | TTL         |
- * |------------------------|---------------------|-------------|
- * | /api/aeds/*            | App (map, list)     | 5 min (anon), none (auth) |
- * | /api/v1/*              | External consumers  | 1h + on-demand invalidation |
- * | /locations/* (ISR)     | SEO / crawlers      | 24h         |
- *
- * On-demand invalidation (revalidatePath):
- * - Single AED change: only stats + detail endpoint
- * - Bulk operations: purge all cached routes
+ * - Single AED change: invalidate v1 detail + stats + v1 city endpoint
+ * - Bulk operations: invalidate all v1 endpoints + ISR location pages
  */
 
-import type { NextRequest } from "next/server";
 import { revalidatePath } from "next/cache";
 
-// ── Cache-Control helpers ───────────────────────────────────────────
-
 /**
- * Cache headers for internal API routes (/api/aeds/*).
- * Authenticated users always get fresh data; anonymous users get 5 min CDN cache.
- *
- * Returns both Cache-Control and CDN-Cache-Control because Next.js 15 on Vercel
- * may override Cache-Control on route handlers. CDN-Cache-Control is respected
- * by Vercel Edge regardless.
+ * Invalidate caches after a single AED is created or updated.
+ * Only targets ISR pages and v1 detail — internal API routes rely on
+ * their 5 min TTL for natural freshness.
  */
-export function getCacheHeaders(request: NextRequest): Record<string, string> {
-  const hasAuth =
-    request.cookies.has("auth-token") ||
-    request.headers.get("authorization")?.startsWith("Bearer ");
-
-  if (hasAuth) {
-    return {
-      "Cache-Control": "private, no-store",
-      "CDN-Cache-Control": "private, no-store",
-    };
-  }
-  return {
-    "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
-    "CDN-Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
-  };
-}
-
-// ── On-demand invalidation ──────────────────────────────────────────
-
-/**
- * Invalidate caches after a single AED is created, updated, or deleted.
- * Only targets specific paths — does NOT purge map/list endpoints
- * (their 5 min TTL handles freshness naturally).
- *
- * Call AFTER the database transaction commits successfully.
- */
-export function invalidateAedCaches(options?: { aedId?: string; communitySlug?: string }): void {
-  // Stats may change (total count, city counts)
+export function invalidateAedCaches(aedId: string): void {
+  revalidatePath(`/api/v1/aeds/${aedId}`, "page");
   revalidatePath("/api/v1/aeds/stats", "page");
-
-  // Specific AED detail (public API, 1h TTL)
-  if (options?.aedId) {
-    revalidatePath(`/api/v1/aeds/${options.aedId}`, "page");
-  }
-
-  // Community location page
-  if (options?.communitySlug) {
-    revalidatePath(`/locations/spain/${options.communitySlug}`, "page");
-  }
 }
 
 /**
- * Invalidate ALL AED caches. Use ONLY for bulk operations
- * (imports, batch deletes, bulk publication changes).
+ * Invalidate ALL AED caches. Use for bulk operations
+ * (imports, batch deletes, bulk publication changes, AED deletion).
  */
 export function invalidateAllAedCaches(): void {
-  // Internal API endpoints (5 min TTL, but force-purge on bulk changes)
-  revalidatePath("/api/aeds", "page");
-  revalidatePath("/api/aeds/by-bounds", "page");
-  revalidatePath("/api/aeds/nearby", "page");
-
-  // Public API v1 (1h TTL)
-  revalidatePath("/api/v1/aeds/nearby", "page");
+  // Public API v1 endpoints
   revalidatePath("/api/v1/aeds/stats", "page");
+  revalidatePath("/api/v1/aeds/nearby", "page");
 
-  // All ISR location pages (24h)
-  revalidatePath("/locations", "page");
+  // ISR location pages
   revalidatePath("/locations/spain", "layout");
   revalidatePath("/sitemap.xml", "page");
 }

--- a/src/lib/cache-invalidation.ts
+++ b/src/lib/cache-invalidation.ts
@@ -1,25 +1,27 @@
 /**
- * On-demand cache invalidation for AED data.
+ * Cache and on-demand invalidation for AED data.
  *
- * Cache strategy:
- * - Authenticated requests: no CDN cache (private, no-store) — always fresh
- * - Anonymous requests: 24h CDN cache — invalidated surgically when AEDs change
- * - Public API v1: 24h CDN cache — invalidated on-demand
- * - ISR pages (/locations/*): 24h revalidate — invalidated on-demand
+ * Cache strategy by audience:
  *
- * IMPORTANT: single-AED mutations only invalidate targeted paths (detail, stats,
- * city page). Map/list endpoints (by-bounds, nearby, /api/aeds) are NOT purged
- * on every change — their SWR policy handles gradual freshness. Only bulk
- * operations (imports, batch deletes) purge everything.
+ * | Route                  | Audience            | TTL         |
+ * |------------------------|---------------------|-------------|
+ * | /api/aeds/*            | App (map, list)     | 5 min (anon), none (auth) |
+ * | /api/v1/*              | External consumers  | 1h + on-demand invalidation |
+ * | /locations/* (ISR)     | SEO / crawlers      | 24h         |
+ *
+ * On-demand invalidation (revalidatePath):
+ * - Single AED change: only stats + detail endpoint
+ * - Bulk operations: purge all cached routes
  */
 
 import type { NextRequest } from "next/server";
 import { revalidatePath } from "next/cache";
 
+// ── Cache-Control helpers ───────────────────────────────────────────
+
 /**
- * Returns the appropriate Cache-Control header based on authentication.
- * Authenticated users get no cache (instant freshness after mutations).
- * Anonymous users get long CDN cache (purged on-demand via invalidation).
+ * Cache-Control for internal API routes (/api/aeds/*).
+ * Authenticated users always get fresh data; anonymous users get 5 min CDN cache.
  */
 export function getCacheControl(request: NextRequest): string {
   const hasAuth =
@@ -29,25 +31,28 @@ export function getCacheControl(request: NextRequest): string {
   if (hasAuth) {
     return "private, no-store";
   }
-  return "public, s-maxage=86400, stale-while-revalidate=172800";
+  return "public, s-maxage=300, stale-while-revalidate=60";
 }
+
+// ── On-demand invalidation ──────────────────────────────────────────
 
 /**
  * Invalidate caches after a single AED is created, updated, or deleted.
- * Only targets specific paths — does NOT purge map/list endpoints.
+ * Only targets specific paths — does NOT purge map/list endpoints
+ * (their 5 min TTL handles freshness naturally).
  *
- * Call this AFTER the database transaction commits successfully.
+ * Call AFTER the database transaction commits successfully.
  */
 export function invalidateAedCaches(options?: { aedId?: string; communitySlug?: string }): void {
   // Stats may change (total count, city counts)
   revalidatePath("/api/v1/aeds/stats", "page");
 
-  // Specific AED detail (public API)
+  // Specific AED detail (public API, 1h TTL)
   if (options?.aedId) {
     revalidatePath(`/api/v1/aeds/${options.aedId}`, "page");
   }
 
-  // Community location page (AED count per community)
+  // Community location page
   if (options?.communitySlug) {
     revalidatePath(`/locations/spain/${options.communitySlug}`, "page");
   }
@@ -58,14 +63,16 @@ export function invalidateAedCaches(options?: { aedId?: string; communitySlug?: 
  * (imports, batch deletes, bulk publication changes).
  */
 export function invalidateAllAedCaches(): void {
-  // Map/list endpoints — only purged on bulk changes
+  // Internal API endpoints (5 min TTL, but force-purge on bulk changes)
   revalidatePath("/api/aeds", "page");
   revalidatePath("/api/aeds/by-bounds", "page");
   revalidatePath("/api/aeds/nearby", "page");
+
+  // Public API v1 (1h TTL)
   revalidatePath("/api/v1/aeds/nearby", "page");
   revalidatePath("/api/v1/aeds/stats", "page");
 
-  // All ISR location pages
+  // All ISR location pages (24h)
   revalidatePath("/locations", "page");
   revalidatePath("/locations/spain", "layout");
   revalidatePath("/sitemap.xml", "page");


### PR DESCRIPTION
## Summary

### Cache por audiencia

| Ruta | Audiencia | TTL | Invalidación |
|------|-----------|-----|-------------|
| `/api/aeds/*` (mapa, lista) | Auth | `private, no-store` | No necesita |
| `/api/aeds/*` (mapa, lista) | Anónimo | **5 min** + 1 min SWR | Bulk ops only |
| `/api/v1/*` (pública) | Externos | **1h** + 2h SWR | On-demand |
| `/locations/*` (ISR) | SEO/crawlers | **24h** | On-demand |

### Invalidación quirúrgica
- **1 AED cambia**: solo purga su detalle (`/api/v1/aeds/{id}`) y stats. Las rutas del mapa NO se purgan — su TTL de 5 min maneja la frescura.
- **Operación bulk** (import, batch delete): purga TODO (mapa, listas, stats, ISR, sitemap).

### `getCacheControl(request)`
Detecta cookie `auth-token` o header `Authorization: Bearer` para decidir:
- Auth → `private, no-store` (siempre fresco)
- Anónimo → `public, s-maxage=300, stale-while-revalidate=60`

### Performance adicional
- DB indexes: `idx_aed_locations_city_name`, `idx_aed_locations_city_code`
- CDN headers: immutable para static assets
- Frontend: coordinate rounding en `useAedsByBounds` para mejor hit rate

## Test plan
- [ ] Logueado: editar DEA → cambios visibles inmediatamente
- [ ] Anónimo: mapa carga con cache CDN (verificar header `s-maxage=300`)
- [ ] Esperar 5 min como anónimo → datos se refrescan vía SWR
- [ ] API v1 GET `/aeds/{id}` → header `s-maxage=3600`
- [ ] Modificar DEA → siguiente GET anónimo a `/api/v1/aeds/{id}` devuelve datos frescos
- [ ] Bulk import → todas las rutas del mapa se purgan