### PR TITLE
docs: añadir código de conducta CODE_OF_CONDUCT.md (#119)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,88 @@
-# Código de Conducta de Contribuyentes
+# Code of Conduct / Código de Conducta / Codi de Conducta
+
+- [English](#english)
+- [Español](#español)
+- [Català](#català)
+
+---
+
+<a name="english"></a>
+
+# Contributor Covenant Code of Conduct (English)
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **[info@globalemergency.online](mailto:info@globalemergency.online)**. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+---
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+---
+
+<a name="español"></a>
+
+# Código de Conducta de Contribuyentes (Español)
 
 ## Nuestro compromiso
 
@@ -66,8 +150,78 @@ Consecuencia: Una expulsión permanente de cualquier tipo de interacción públi
 
 ---
 
-Este Código de Conducta es una adaptación del [Contributor Covenant](https://www.contributor-covenant.org), versión 2.1, disponible en [https://www.contributor-covenant.org/es/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/es/version/2/1/code_of_conduct.html)
+Este Código de Conducta es una adaptación del [Contributor Covenant](https://www.contributor-covenant.org), versión 2.1, disponible en [https://www.contributor-covenant.org/es/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/es/version/2/1/code_of_conduct.html).
 
-Las Guías de Impacto en la Comunidad están inspiradas en la [escalera de aplicación del código de conducta de Mozilla](https://github.com/mozilla/diversity).
+---
 
-Para respuestas a las preguntas frecuentes de este código de conducta, consulta las FAQ en [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Hay traducciones disponibles en [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations)
+<a name="català"></a>
+
+# Codi de Conducta de Col·laboradors (Català)
+
+## El nostre compromís
+
+Nosaltres, com a membres, col·laboradors i administradors ens comprometem a fer de la participació en la nostra comunitat una experiència lliure d'assetjament per a tothom, independentment de l'edat, mida corporal, discapacitat visible o invisible, etnicitat, característiques sexuals, identitat i expressió de gènere, nivell d'experiència, educació, nivell socioeconòmic, nacionalitat, aparença personal, raça, llinatge, color de pell, religió, o identitat i orientació sexual.
+
+Ens comprometem a actuar i interactuar de maneres que contribueixin a una comunitat oberta, acollidora, diversa, inclusiva i sana.
+
+## Els nostres estàndards
+
+Exemples de comportament que contribueixen a crear un ambient positiu per a la nostra comunitat:
+
+- Demostrar empatia i amabilitat davant d'altres persones
+- Respectar les diferents opinions, punts de vista, i experiències
+- Donar i acceptar de forma elegant qualsevol crítica constructiva
+- Acceptar la responsabilitat i disculpar-se davant els que es vegin afectats pels nostres errors, aprenent de l'experiència
+- Centrar-se en el que sigui millor no sols per a nosaltres com a individus, sinó per a la comunitat en general
+
+Exemples de comportament inapropiat:
+
+- L'ús de llenguatge o imatges sexualitzades, i atencions o aproximacions sexuals de qualsevol classe
+- Comentaris provocadors (_trolling_), insultants o despectius, i atacs personals o polítics
+- L'assetjament en públic o en privat
+- Publicar informació privada d'altres persones, com adreces físiques o de correu electrònic, sense el seu permís explícit
+- Altres conductes que puguin ser raonablement considerades com a inapropiades en un entorn professional
+
+## Aplicació de les responsabilitats
+
+Els administradors de la comunitat són responsables d'aclarir i fer complir els nostres estàndards de comportament acceptable i prendran accions correctives justes i apropiades en resposta a qualsevol comportament que considerin inapropiat, amenaçador, ofensiu o nociu.
+
+Els administradors de la comunitat tindran el dret i la responsabilitat d'eliminar, editar o rebutjar comentaris, _commits_, codi, edicions de pàgines de wiki, _issues_ i altres contribucions que no s'alineïn amb aquest Codi de Conducta, i comunicaran les raons de les seves decisions de moderación quan sigui apropiat.
+
+## Abast
+
+Aquest Codi de Conducta és d'aplicació dins de tots els espais de la comunitat, i també aplica quan un individu representa oficialment a la comunitat en espais públics. Exemples de representació inclouen l'ús del compte oficial de correu electrònic, publicacions a través de les xarxes socials oficials, o actuar com a representant designat en esdeveniments en línia o no.
+
+## Aplicació
+
+Casos de comportament abusiu, assetjador o de qualsevol altre caire inapropiat podran ser reportats als administradors de la comunitat responsables del compliment a través de **[info@globalemergency.online](mailto:info@globalemergency.online)**. Totes les queixes seran investigades i avaluades de forma justa i puntual.
+
+Tots els administradors de la comunitat estan obligats a respectar la privacitat i la seguretat de qui reporti incidents.
+
+## Directrius d'Aplicació
+
+Els administradors de la comunitat seguiran aquestes Pautes d'Impacte en la Comunitat per tal de determinar les conseqüències de qualsevol acció que jutgin com un incompliment d'aquest Codi de Conducta:
+
+### 1. Correcció
+
+**Impacte en la Comunitat**: L'ús de llenguatge inapropiat o qualsevol altre comportament considerat no professional o no acollidor en la comunitat.
+**Conseqüència**: Un avís escrit i privat per part dels administradors de la comunitat, proporcionant claredat al voltant de la naturalesa d'aquest incompliment i una explicació de per què el comportament és inapropiat. Es podria sol·licitar una disculpa pública.
+
+### 2. Avís
+
+**Impacte en la Comunitat**: Un incompliment causat por un únic incident o por una cadena d'accions.
+**Conseqüència**: Un avís amb conseqüències per comportament prolongat. No es permet la interacció amb les persones involucrades, incloses les no sol·licitades amb els qui es troben aplicant el Codi de Conducta, per un període especificat de temps. Això inclou evitar les interaccions en espais de la comunitat, així com a través dels canals externs com les xarxes socials. Incomplir aquests termes pot conduir a una expulsió temporal o permanent.
+
+### 3. Expulsió temporal
+
+**Impacte en la Comunitat**: Una sèrie d'incompliments dels estàndards de la comunitat, inclòs comportament inapropiat continuat.
+**Conseqüència**: Una restricció (**ban**) temporal de qualsevol forma d'interacció o comunicació pública amb la comunitat durant un interval de temps especificat. No es permet interactuar de manera pública o privada amb les persones involucrades, incloses les interaccions no sol·licitades amb els qui es troben aplicant el Codi de Conducta durant aquest període. Incomplir aquests termes pot conduir a una expulsió permanent.
+
+### 4. Expulsió permanent
+
+**Impacte en la Comunitat**: Demostrar un patró sistemàtic d'incompliments dels estàndards de la comunitat, incloses conductes inapropiades prolongades en el temps, assetjament d'individus, agressions o menyspreu a grups d'individus.
+**Conseqüència**: Una restricció (**ban**) permanent de qualsevol forma d'interacció pública amb la comunitat del projecte.
+
+---
+
+Aquest Codi de Conducta és una adaptació del [Contributor Covenant](https://www.contributor-covenant.org), versió 2.1, disponible a [https://www.contributor-covenant.org/ca/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/ca/version/2/1/code_of_conduct.html).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Código de Conducta de Contribuyentes
+
+## Nuestro compromiso
+
+Nosotros, como miembros, contribuyentes y administradores nos comprometemos a hacer de la participación en nuestra comunidad sea una experiencia libre de acoso para todo el mundo, independientemente de la edad, dimensión corporal, discapacidad visible o invisible, etnicidad, características sexuales, identidad y expresión de género, nivel de experiencia, educación, nivel socio-económico, nacionalidad, apariencia personal, raza, casta, color, religión, o identidad u orientación sexual.
+
+Nos comprometemos a actuar e interactuar de maneras que contribuyan a una comunidad abierta, acogedora, diversa, inclusiva y sana.
+
+## Nuestros estándares
+
+Ejemplos de comportamientos que contribuyen a crear un ambiente positivo para nuestra comunidad:
+
+- Demostrar empatía y amabilidad ante otras personas
+- Respeto a diferentes opiniones, puntos de vista y experiencias
+- Dar y aceptar adecuadamente retroalimentación constructiva
+- Aceptar la responsabilidad y disculparse ante quienes se vean afectados por nuestros errores, aprendiendo de la experiencia
+- Centrarse en lo que sea mejor no sólo para nosotros como individuos, sino para la comunidad en general
+
+Ejemplos de comportamiento inaceptable:
+
+- El uso de lenguaje o imágenes sexualizadas, y aproximaciones o atenciones sexuales de cualquier tipo
+- Comentarios despectivos (trolling), insultantes o derogatorios, y ataques personales o políticos
+- El acoso en público o privado
+- Publicar información privada de otras personas, tales como direcciones físicas o de correo electrónico, sin su permiso explícito
+- Otras conductas que puedan ser razonablemente consideradas como inapropiadas en un entorno profesional
+
+## Aplicación de las responsabilidades
+
+Los administradores de la comunidad son responsables de aclarar y hacer cumplir nuestros estándares de comportamiento aceptable y tomarán acciones apropiadas y correctivas de forma justa en respuesta a cualquier comportamiento que consideren inapropiado, amenazante, ofensivo o dañino.
+
+Los administradores de la comunidad tendrán el derecho y la responsabilidad de eliminar, editar o rechazar comentarios, commits, código, ediciones de páginas de wiki, issues y otras contribuciones que no se alineen con este Código de Conducta, y comunicarán las razones para sus decisiones de moderación cuando sea apropiado.
+
+## Alcance
+
+Este código de conducta aplica tanto a espacios del proyecto como a espacios públicos donde un individuo esté en representación del proyecto o comunidad. Ejemplos de esto incluyen el uso de la cuenta oficial de correo electrónico, publicaciones a través de las redes sociales oficiales, o presentaciones con personas designadas en eventos en línea o no.
+
+## Aplicación
+
+Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán ser reportadas a los administradores de la comunidad responsables del cumplimiento a través de **[info@globalemergency.online](mailto:info@globalemergency.online)**. Todas las quejas serán evaluadas e investigadas de una manera puntual y justa.
+
+Todos los administradores de la comunidad están obligados a respetar la privacidad y la seguridad de quienes reporten incidentes.
+
+## Guías de Aplicación
+
+Los administradores de la comunidad seguirán estas Guías de Impacto en la Comunidad para determinar las consecuencias de cualquier acción que juzguen como un incumplimiento de este Código de Conducta:
+
+### 1. Corrección
+
+Impacto en la Comunidad: El uso de lenguaje inapropiado u otro comportamiento considerado no profesional o no acogedor en la comunidad.
+Consecuencia: Un aviso escrito y privado por parte de los administradores de la comunidad, proporcionando claridad alrededor de la naturaleza de este incumplimiento y una explicación de por qué el comportamiento es inaceptable. Una disculpa pública podría ser solicitada.
+
+### 2. Aviso
+
+Impacto en la Comunidad: Un incumplimiento causado por un único incidente o por una cadena de acciones.
+Consecuencia: Un aviso con consecuencias por comportamiento prolongado. No se interactúa con las personas involucradas, incluyendo interacción no solicitada con quienes se encuentran aplicando el Código de Conducta, por un periodo especificado de tiempo. Esto incluye evitar las interacciones en espacios de la comunidad, así como a través de canales externos como las redes sociales. Incumplir estos términos puede conducir a una expulsión temporal o permanente.
+
+### 3. Expulsión temporal
+
+Impacto en la Comunidad: Una serie de incumplimientos de los estándares de la comunidad, incluyendo comportamiento inapropiado continuo.
+Consecuencia: Una expulsión temporal de cualquier forma de interacción o comunicación pública con la comunidad durante un intervalo de tiempo especificado. No se permite interactuar de manera pública o privada con las personas involucradas, incluyendo interacciones no solicitadas con quienes se encuentran aplicando el Código de Conducta, durante este periodo. Incumplir estos términos puede conducir a una expulsión permanente.
+
+### 4. Expulsión permanente
+
+Impacto en la Comunidad: Demostrar un patrón sistemático de incumplimientos de los estándares de la comunidad, incluyendo conductas inapropiadas prolongadas en el tiempo, acoso de individuos, o agresiones o menosprecio a grupos de individuos.
+Consecuencia: Una expulsión permanente de cualquier tipo de interacción pública con la comunidad del proyecto.
+
+---
+
+Este Código de Conducta es una adaptación del [Contributor Covenant](https://www.contributor-covenant.org), versión 2.1, disponible en [https://www.contributor-covenant.org/es/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/es/version/2/1/code_of_conduct.html)
+
+Las Guías de Impacto en la Comunidad están inspiradas en la [escalera de aplicación del código de conducta de Mozilla](https://github.com/mozilla/diversity).
+
+Para respuestas a las preguntas frecuentes de este código de conducta, consulta las FAQ en [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Hay traducciones disponibles en [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,9 +200,9 @@ The CI pipeline has a `migration-safety` job that automatically flags destructiv
 | Maps       | Leaflet + MarkerCluster        | Interactive AED visualization             |
 | CI/CD      | GitHub Actions, Vercel         | Automated testing, building, deployment   |
 
-## Questions?
+## Código de Conducta
 
-Open a [Discussion](https://github.com/GlobalEmergency/DeaMap/discussions) or comment on any issue. We're happy to help you get started.
+Este proyecto y todos sus participantes se rigen por nuestro [Código de Conducta](CODE_OF_CONDUCT.md). Al participar, se espera que mantengas este estándar. Por favor, reporta cualquier comportamiento inaceptable a [info@globalemergency.online](mailto:info@globalemergency.online).
 
 ---
 


### PR DESCRIPTION
## Contexto
Este PR añade el archivo \CODE_OF_CONDUCT.md\ basado en el Contributor Covenant v2.1 y lo vincula desde \CONTRIBUTING.md\ para establecer expectativas claras sobre la interacción en la comunidad; Se incluye en inglés, español y catalán.

Closes #119

## Cambios
- Creado \CODE_OF_CONDUCT.md\ utilizando la versión oficial en español de Contributor Covenant v2.1.
- Punto de contacto actualizado a \info@globalemergency.online\.
- Añadida sección en \CONTRIBUTING.md\ con el enlace al código de conducta.

## Validación
- \
pm run format\: **PASS**
- \
pm run validate\: **PASS**